### PR TITLE
Change "stackoverflow" to "Stack Overflow"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Uses the technique described here:
 
 [LITTLE PLANET PHOTOS: 5 SIMPLE STEPS TO MAKING PANORAMA WORLDS](https://www.photographymad.com/pages/view/little-planet-photos-5-simple-steps-to-making-panorama-worlds)
 
-Code for the polar distort originally from a stackoverflow answer: [Image to polar co-ordinates](https://stackoverflow.com/a/48053026/150882)
+Code for the polar distort originally from a Stack Overflow answer: [Image to polar co-ordinates](https://stackoverflow.com/a/48053026/150882)


### PR DESCRIPTION
Corrected site spelling from "stackoverflow" to "Stack Overflow"